### PR TITLE
fix: enum backing type and compiling against newer protobuf versions

### DIFF
--- a/source/odin-code-generator.cpp
+++ b/source/odin-code-generator.cpp
@@ -155,7 +155,7 @@ static bool PrintField(const FieldDescriptor &field_desc, Context *const context
 	// TODO: handle default values
 
 	const std::map<std::string, std::string> vars{
-		{"name", field_desc.name()},
+		{"name", std::string(field_desc.name())},
 		{"odin_type", GetOdinFieldTypeName(field_desc, context->proto_package)},
 		{"id", fmt::to_string(field_desc.number())},
 		{"proto_type", fmt::to_string((int) field_desc.type())},
@@ -191,7 +191,7 @@ static bool PrintField(const FieldDescriptor &field_desc, Context *const context
 static bool PrintOneof(const OneofDescriptor &oneof_desc, Context *const context)
 {
 	std::map<std::string, std::string> vars{
-		{"name", oneof_desc.name()},
+		{"name", std::string(oneof_desc.name())},
 	};
 
 	context->printer.Print(vars, "\n$name$: struct #raw_union {\n");
@@ -226,7 +226,7 @@ static bool PrintEnum(const EnumDescriptor &enum_desc, Context *const context)
 	{
 		const EnumValueDescriptor &value_desc = *enum_desc.value(idx);
 
-		vars["name"] = value_desc.name();
+		vars["name"] = std::string(value_desc.name());
 		vars["value"] = fmt::to_string(value_desc.number());
 
 		context->printer.Print(vars, "$name$ = $value$,\n");

--- a/source/odin-code-generator.cpp
+++ b/source/odin-code-generator.cpp
@@ -217,7 +217,7 @@ static bool PrintEnum(const EnumDescriptor &enum_desc, Context *const context)
 		{"name", ConvertFullTypeName(enum_desc.full_name(), context->proto_package)},
 	};
 
-	context->printer.Print(vars, "\n$name$ :: enum {\n");
+	context->printer.Print(vars, "\n$name$ :: enum i32 {\n");
 	context->printer.Indent();
 
 	vars.clear();


### PR DESCRIPTION
This fixes the enum backing type I outlined in [this pr](https://github.com/lordhippo/odin-protobuf/pull/17), along with compiling fix for newer protobuf versions.

Let me know if there are any questions :).

Edit: CI works now, compiled protobuf 6.33.4 (at time of testing). Vcpkg got bumped to 2026.06.01 (f3e10653).

When I ran the CI on my fork I had the following build times (cold cache mind you):

linux-debug on ubuntu-latest | 12m 18s |  
-- | -- | --
windows-debug on windows-latest | 20m 36s |  
windows-release on windows-latest | 18m 38s |  
macos-debug on macos-latest | 9m 21s |  
  | 1h 0m 55s |  